### PR TITLE
Clear message input field once message is sent

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -50,6 +50,21 @@ Hooks.MicButton = {
   },
 };
 
+Hooks.MessageInput = {
+  mounted() {
+    this.el.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        const message = this.el.value;
+        if (message.trim() !== "") {
+          this.pushEvent("send_message", { message });
+          this.el.value = "";
+        }
+      }
+    });
+  }
+}
+
 let granted = false;
 Hooks.PushNotification = {
   mounted() {

--- a/lib/walkie_tokie/context_supervisor/receiver.ex
+++ b/lib/walkie_tokie/context_supervisor/receiver.ex
@@ -56,9 +56,11 @@ defmodule WalkieTokie.Receiver do
       from_node_name: inspect(from_node_name),
       length: byte_size(chunk)
     )
+
     Appsignal.set_gauge("data_download", byte_size(chunk))
 
     Appsignal.set_gauge("node_data_download", byte_size(chunk), %{node: inspect(Node.self())})
+
     PubSub.broadcast(
       WalkieTokie.PubSub,
       "node_speaking",

--- a/lib/walkie_tokie_web/live/walkie_tokie_live.html.heex
+++ b/lib/walkie_tokie_web/live/walkie_tokie_live.html.heex
@@ -3,7 +3,6 @@
 </div>
 
 <div class="flex flex-col h-screen bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-  
   <header class="bg-purple-700 text-white p-4 shadow-md dark:bg-purple-900 flex-shrink-0">
     <div class="flex items-center justify-between">
       <h1 class="flex items-center gap-2 text-xl font-semibold">
@@ -30,14 +29,12 @@
   </header>
 
   <div class="flex border-b border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 flex-shrink-0">
-    
     <div class="w-1/3 lg:w-1/4 p-4 border-r border-gray-300 dark:border-gray-700">
       <h3 class="text-sm font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">
         Usuários Online
       </h3>
     </div>
     <div class="flex-1 p-4">
-      
       <h3 class="text-sm font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">
         Mensagens
       </h3>
@@ -45,10 +42,7 @@
   </div>
 
   <div class="flex flex-1 overflow-hidden">
-    
     <aside class="w-1/3 lg:w-1/4 flex flex-col border-r border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800">
-      
-
       <div class="flex-1 overflow-y-auto p-4 space-y-2">
         <%= for user <- Enum.sort_by(@users, &(!&1.is_speaking)) do %>
           <div class={[
@@ -115,8 +109,6 @@
     </aside>
 
     <section class="flex-1 flex flex-col bg-gray-50 dark:bg-gray-850">
-      
-
       <div id="message-list" class="flex-1 overflow-y-auto p-4 space-y-4">
         <%= for message <- @messages do %>
           <% is_own_message = message.user.id == @user.id %>
@@ -159,8 +151,10 @@
       </div>
 
       <div class="p-4 border-t border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 flex-shrink-0">
-        <form phx-submit="send_message" class="flex items-center gap-3">
+        <form class="flex items-center gap-3">
           <input
+            phx-hook="MessageInput"
+            id="message-input"
             type="text"
             name="message"
             placeholder="Digite sua mensagem..."
@@ -178,7 +172,6 @@
       </div>
     </section>
   </div>
-  
 
   <footer class="p-3 text-center text-xs text-gray-500 bg-gray-100 dark:bg-gray-800 dark:text-gray-400 border-t border-gray-300 dark:border-gray-700 flex-shrink-0">
     <p class="flex items-center justify-center gap-1 mb-1">


### PR DESCRIPTION
When messages are sent, the input field is not cleared for new message requiring a manual clearing.

I adapted it to clear the field for once when the message is sent.